### PR TITLE
Cleared force push prohibited patterns

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GitSharedSettings">
+    <option name="FORCE_PUSH_PROHIBITED_PATTERNS">
+      <list />
+    </option>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>


### PR DESCRIPTION
**PR Type**  
- [x] Other: IDE configuration

**Describe changes**  
Cleared force push prohibited patterns.
They are not needed due to GitHub branch rules.

**What is the current behavior?**  
CLion wouldn't allow force pushing changes to the `master` or `main` branches.

**What is the new behavior?**  
CLion allows force pushing changes to the `master` or `main` branches.
Most of the time, the push will still be rejected due to GitHub branch rules.
However, when the force push to the default branch is required, it will now be faster and easier since changing the IDE configuration for this action is no longer necessary.