### PR TITLE
Added CMake profile configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,28 @@ set_project_directories(src src test res include lib out)
 
 # EXECUTABLE
 set(EXECUTABLE_NAME ${CMAKE_PROJECT_NAME})
+set(EXECUTABLE_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${EXECUTABLE_NAME})
 add_executable(${EXECUTABLE_NAME} ${HEADER_FILES} ${SOURCE_FILES})
+
+
+# PROFILES
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+	target_compile_definitions(${EXECUTABLE_NAME} PRIVATE DEBUG _DEBUG DEBUG_MODE)
+	target_compile_options(${EXECUTABLE_NAME} PRIVATE -Wall -O0 -g3)
+elseif (CMAKE_BUILD_TYPE STREQUAL "Release")
+	target_compile_definitions(${EXECUTABLE_NAME} PRIVATE RELEASE _RELEASE RELEASE_MODE NDEBUG NO_DEBUG)
+	target_compile_options(${EXECUTABLE_NAME} PRIVATE -O3 -flto -s -Wl,-s -Wl,--gc-sections)
+	add_strip_command(${EXECUTABLE_NAME} ${EXECUTABLE_PATH} OPTIONS -s)
+elseif (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+	target_compile_definitions(${EXECUTABLE_NAME} PRIVATE RELEASE _RELEASE RELEASE_MODE NDEBUG NO_DEBUG RELWITHDEBINFO)
+	target_compile_options(${EXECUTABLE_NAME} PRIVATE -O2 -flto -g3)
+elseif (CMAKE_BUILD_TYPE STREQUAL "MinSize" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+	target_compile_definitions(${EXECUTABLE_NAME} PRIVATE RELEASE _RELEASE RELEASE_MODE NDEBUG NO_DEBUG MINSIZE MINSIZEREL)
+	target_compile_options(${EXECUTABLE_NAME} PRIVATE -Os -flto -s -Wl,-s -Wl,--gc-sections)
+	add_strip_command(${EXECUTABLE_NAME} ${EXECUTABLE_PATH} OPTIONS -s)
+else()
+	# do nothing
+endif()
 
 
 # LIBRARIES

--- a/Functions.cmake
+++ b/Functions.cmake
@@ -182,3 +182,15 @@ function(set_project_directories HEADER_DIR SOURCE_DIR TEST_DIR RESOURCE_DIR INC
 	set(LIB_FILES ${LIB_FILES} PARENT_SCOPE)
 
 endfunction()
+
+# Adds `strip` command for the executable
+function(add_strip_command EXECUTABLE_NAME EXECUTABLE_PATH)
+	cmake_parse_arguments(STRIP "" "" "OPTIONS" ${ARGN})
+	add_custom_command(TARGET ${EXECUTABLE_NAME} POST_BUILD
+			COMMAND strip ${STRIP_OPTIONS} ${EXECUTABLE_PATH}
+			COMMENT "Stripping executable: ${EXECUTABLE_NAME}")
+	if(PRINT_EXECUTABLE_SIZE)
+		add_custom_command(TARGET ${EXECUTABLE_NAME} POST_BUILD VERBATIM
+				COMMAND bash -c "size=$(stat -c%s ${EXECUTABLE_PATH}); printf 'Size after 'strip' command: %${EXECUTABLE_SIZE_OUTPUT_LENGTH}d bytes\\n' $size")
+	endif()
+endfunction()

--- a/Functions.cmake
+++ b/Functions.cmake
@@ -189,8 +189,4 @@ function(add_strip_command EXECUTABLE_NAME EXECUTABLE_PATH)
 	add_custom_command(TARGET ${EXECUTABLE_NAME} POST_BUILD
 			COMMAND strip ${STRIP_OPTIONS} ${EXECUTABLE_PATH}
 			COMMENT "Stripping executable: ${EXECUTABLE_NAME}")
-	if(PRINT_EXECUTABLE_SIZE)
-		add_custom_command(TARGET ${EXECUTABLE_NAME} POST_BUILD VERBATIM
-				COMMAND bash -c "size=$(stat -c%s ${EXECUTABLE_PATH}); printf 'Size after 'strip' command: %${EXECUTABLE_SIZE_OUTPUT_LENGTH}d bytes\\n' $size")
-	endif()
 endfunction()


### PR DESCRIPTION
**PR Type**  
- [x] Other: CMake configuration

**Describe changes**  
Added CMake profile configuration.

1. Added `EXECUTABLE_PATH` variable.
2. Added `add_strip_command` function for the `strip` command after the build.
3. Added configuration for "Debug", "Release", "RelWithDebInfo" and "MinSize"/"MinSizeRel" profiles.

"MinSize" and "MinSizeRel" profiles are the same thing.

**What is the current behavior?**  
The default CMake configuration is applied for every profile.
No `strip` command is executed after the build in any profile.

**What is the new behavior?**  
Every profile has its own configuration.
The `strip` command is executed after the build for `Release` and `MinSize`/`MinSizeRel` profiles.

**How to test**  
Run build in different profiles and compare the results.